### PR TITLE
Finalizing superlinter for continuous integration

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,6 +1,6 @@
 name: super-linter
 
-on: push
+on: pull_request
 
 jobs:
   super-lint:


### PR DESCRIPTION
This superlinter will lint our pull requests. This acts as our CI.