### PR TITLE
Only send code to GCP on push to main: CD Finalization

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,7 +3,10 @@
 
 name: Send to code GCP
 
-on: push
+on: 
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
Add a filter the YAML file to only trigger the workflow on push to main