### PR TITLE
Changes to /package endpoint and metadata model

### DIFF
--- a/web/src/models/packageMetadata.js
+++ b/web/src/models/packageMetadata.js
@@ -4,8 +4,7 @@ const packageID = require('./packageID')
 
 const packageMetadataSchema = new mongoose.Schema({
     Name: {
-        ref: 'PackageName',
-        type: mongoose.Schema.Types.ObjectId,
+        type: String,
         description: 'Package Name',
         example: 'my-package',
         required: true
@@ -14,13 +13,6 @@ const packageMetadataSchema = new mongoose.Schema({
         description: 'Package Version',
         type: String,
         example: '1.2.3',
-        required: true
-    },
-    ID: {
-        ref: 'PackageID',
-        type: mongoose.Schema.Types.ObjectId,
-        description: 'Unique ID for use with the /package/{id} endpoint.',
-        example: '123567192081501',
         required: true
     }
 })

--- a/web/src/routes/package.js
+++ b/web/src/routes/package.js
@@ -51,29 +51,23 @@ package_router.post('/', async (req,res) => {
                     res.status(409).json({ message: 'Package exists already.' })
                 }
                 else {
-                    // Create unique ID and make PackageID schema
-                    let ID = uuidv4();
-                    while(await PackageID.findOne({ PackageID: ID }) != null) {
-                        ID = uuidv4();
-                    }
-                    const newPackageIDSchema = new PackageID({
-                        PackageID: ID
-                    })
-
                     // Get name and version from package.json
                     const base64Content = newPackageDataSchema.Content
                     let newName
                     let newVersion
+                    let newURL
                     let zipError = false
+                    let isName = true
                     try {
                         // Decode content, extract package.json, then extract name and version from it
                         const decodedContent = Buffer.from(base64Content, 'base64')
                         const zip = await JSZip.loadAsync(decodedContent)
                         const packageJSON = await zip.file('package.json').async('string')
                         newName = JSON.parse(packageJSON).name
-                        if(!newName) newName = ID
+                        if(!newName) isName = false
                         newVersion = JSON.parse(packageJSON).version
                         if(!newVersion) newVersion = "1.0.0"
+                        newURL = JSON.parse(packageJSON).homepage
                     }
                     catch {
                         // Per piazza post 196
@@ -82,21 +76,25 @@ package_router.post('/', async (req,res) => {
                     }
 
                     if(!zipError) {
-                        // Create packageName schema
-                        const newPackageNameSchema = new PackageName ({
-                            PackageName: newName
-                        })
-
-                        await newPackageNameSchema.save()
+                        // Add URL for later use if needed
+                        newPackageDataSchema.URL = newURL
                         await newPackageDataSchema.save()
-                        await newPackageIDSchema.save()
 
                         // Create packageMetadata schema
                         const newPackageMetadataSchema = new PackageMetadata ({
-                            Name: newPackageNameSchema._id,
+                            Name: "default",
                             Version: newVersion,
-                            ID: newPackageIDSchema._id
                         })
+
+                        await newPackageMetadataSchema.save()
+
+                        // Set name accordingly 
+                        if(isName) {
+                            newPackageMetadataSchema.Name = newName
+                        } 
+                        else {
+                            newPackageMetadataSchema.Name = _id
+                        }
 
                         await newPackageMetadataSchema.save()
 


### PR DESCRIPTION
1. Metadata no longer uses packageName schema
2. URL is set when zip file is uploaded. It is always homepage per piazza post https://piazza.com/class/lc9qx1w86k643t/post/230
3. Uses internal ID instead of us creating one, so PackageID schema no longer used 
